### PR TITLE
Fix validator class not found

### DIFF
--- a/formwidgets/UnsplashPicker.php
+++ b/formwidgets/UnsplashPicker.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Response;
 use October\Rain\Exception\ApplicationException;
 use October\Rain\Exception\ValidationException;
-use October\Rain\Support\Facades\Validator;
+use Illuminate\Support\Facades\Validator;
 use SunLab\UnsplashPicker\Models\Settings;
 
 class UnsplashPicker extends FileUpload

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,3 +1,4 @@
 1.0.1: First version of UnsplashPicker
 1.0.2: Fix for attachOne relationships
 1.0.3: Fix fileupload assets not loaded
+1.0.4: Fix Validator class not found


### PR DESCRIPTION
This was due to the fact Sam removed the Rain Validator wrapper class here: https://github.com/octobercms/library/commit/4405f43ab620031cbc5f88ad8145e0c812cdb41b#diff-2ac352318ffd3892ff2e749ddd175a1e8f198f8a1108ffd2f8fcf83542d2a5b8